### PR TITLE
Apply hypermodern look across static pages

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,200 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Digitale Visitekaart - Dashboard</title>
+    <meta
+      name="description"
+      content="Bewerk je digitale visitekaart en deel hem met anderen."
+    />
+    <link rel="icon" href="./favicon.svg" />
+    <link rel="stylesheet" href="theme.hypermodern.css" />
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body class="page-dashboard" data-page="dashboard">
+    <header class="site-header u-navbar">
+      <div class="inner">
+        <div class="site-brand">
+          <a href="./index.html">Digitale Visitekaart</a>
+        </div>
+        <nav class="site-nav" aria-label="Hoofdmenu">
+          <a href="./index.html">Start</a>
+          <a href="./profile.html">Profiel</a>
+          <a href="./card.html">Kaart</a>
+          <a href="./dashboard.html">Dashboard</a>
+          <a href="./settings.html">Instellingen</a>
+          <a href="./privacy.html">Privacy</a>
+          <a href="./terms.html">Voorwaarden</a>
+          <a href="./cookies.html">Cookies</a>
+        </nav>
+      </div>
+    </header>
+
+    <div class="page-content">
+      <div class="editor-wrap container">
+        <section class="hero">
+          <div class="content">
+            <header class="editor-header">
+              <h1>Digitale Visitekaart</h1>
+              <p class="muted">Bewerk je digitale visitekaart en deel hem met anderen.</p>
+            </header>
+          </div>
+          <div class="actions hero-actions">
+            <button id="btnLogout" class="u-btn u-btn--ghost" type="button">Uitloggen</button>
+            <button id="btnShare" class="u-btn u-btn--primary" type="button">Delen</button>
+            <button id="btnVCard" class="u-btn u-btn--ghost" type="button">Download vCard</button>
+          </div>
+        </section>
+
+        <main class="editor-main">
+          <section class="card u-card" aria-labelledby="previewTitle">
+            <h2 id="previewTitle" class="muted">Voorbeeldkaart</h2>
+            <div class="preview">
+              <img id="avatarPreview" class="avatar" alt="Profielfoto" />
+              <div>
+                <div class="name" id="namePreview">Jouw Naam</div>
+                <div class="title" id="titlePreview">Functie</div>
+                <div class="company" id="companyPreview">Bedrijf</div>
+                <div class="contact">
+                  <a href="#" id="emailLink" aria-disabled="true">E-mail</a>
+                  <a href="#" id="telLink" aria-disabled="true">Telefoon</a>
+                  <a href="#" id="webLink" aria-disabled="true">Website</a>
+                  <a href="#" id="liLink" aria-disabled="true">LinkedIn</a>
+                  <a href="#" id="igLink" aria-disabled="true">Instagram</a>
+                  <a href="#" id="xLink" aria-disabled="true">X</a>
+                </div>
+              </div>
+            </div>
+            <p id="tagline"></p>
+          </section>
+
+          <section class="card u-card" aria-labelledby="editTitle">
+            <h2 id="editTitle" class="muted">Bewerken</h2>
+            <form id="editForm">
+              <div class="grid-2 grid cols-2">
+                <div>
+                  <label for="fieldName">Naam</label>
+                  <input id="fieldName" class="u-input" name="name" placeholder="Jouw Naam" />
+                </div>
+                <div>
+                  <label for="fieldTitle">Functie</label>
+                  <input id="fieldTitle" class="u-input" name="title" placeholder="Bijv. Founder" />
+                </div>
+              </div>
+              <div class="grid-2 grid cols-2">
+                <div>
+                  <label for="fieldCompany">Bedrijf</label>
+                  <input
+                    id="fieldCompany"
+                    class="u-input"
+                    name="company"
+                    placeholder="Bedrijfsnaam"
+                  />
+                </div>
+                <div>
+                  <label for="fieldWebsite">Website</label>
+                  <input
+                    id="fieldWebsite"
+                    class="u-input"
+                    name="website"
+                    placeholder="https://..."
+                  />
+                </div>
+              </div>
+              <div class="grid-2 grid cols-2">
+                <div>
+                  <label for="fieldEmail">E-mail</label>
+                  <input
+                    id="fieldEmail"
+                    class="u-input"
+                    name="email"
+                    type="email"
+                    placeholder="jij@voorbeeld.nl"
+                  />
+                </div>
+                <div>
+                  <label for="fieldPhone">Telefoon</label>
+                  <input
+                    id="fieldPhone"
+                    class="u-input"
+                    name="phone"
+                    placeholder="+31..."
+                  />
+                </div>
+              </div>
+              <div class="grid-2 grid cols-2">
+                <div>
+                  <label for="fieldLinkedIn">LinkedIn</label>
+                  <input
+                    id="fieldLinkedIn"
+                    class="u-input"
+                    name="linkedin"
+                    placeholder="https://linkedin.com/in/..."
+                  />
+                </div>
+                <div>
+                  <label for="fieldInstagram">Instagram</label>
+                  <input
+                    id="fieldInstagram"
+                    class="u-input"
+                    name="instagram"
+                    placeholder="https://instagram.com/..."
+                  />
+                </div>
+              </div>
+              <div class="grid-2 grid cols-2">
+                <div>
+                  <label for="fieldX">X (Twitter)</label>
+                  <input
+                    id="fieldX"
+                    class="u-input"
+                    name="x"
+                    placeholder="https://x.com/..."
+                  />
+                </div>
+                <div aria-hidden="true"></div>
+              </div>
+              <div>
+                <label for="fieldAvatar">Profielfoto (URL)</label>
+                <input
+                  id="fieldAvatar"
+                  class="u-input"
+                  name="avatar"
+                  placeholder="https://...jpg"
+                />
+              </div>
+              <div>
+                <label for="fieldBio">Korte bio / tagline</label>
+                <textarea
+                  id="fieldBio"
+                  class="u-input"
+                  name="bio"
+                  rows="3"
+                  placeholder="Wat doe jij?"
+                ></textarea>
+              </div>
+              <div class="row">
+                <button id="btnGenerate" class="u-btn u-btn--ghost" type="button">
+                  Genereer tagline met AI
+                </button>
+                <span class="pill">OpenAI-sleutel vereist</span>
+              </div>
+            </form>
+            <div class="notice" role="status">
+              Configureer het endpoint <code>/api/generate</code> met een OpenAI-sleutel om automatisch een tagline
+              te genereren.
+            </div>
+          </section>
+        </main>
+
+        <footer class="editor-footer u-footer">
+          Bewaar je wijzigingen lokaal en deel je kaart. De AI-functie gebruikt het serverless endpoint met
+          <code>OPENAI_API_KEY</code>.
+        </footer>
+      </div>
+    </div>
+
+    <script src="./app.js"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
       content="Bouw en deel eenvoudig een digitale visitekaart met AI-taglines."
     />
     <link rel="icon" href="/favicon.svg" />
+    <link rel="stylesheet" href="theme.hypermodern.css" />
     <script>
       if (!localStorage.getItem('user:email')) {
         window.location.replace('home.html');

--- a/login.html
+++ b/login.html
@@ -1,0 +1,156 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Digitale Visitekaart - Aanmelden</title>
+    <meta
+      name="description"
+      content="Meld je aan om je digitale visitekaart te bouwen en delen."
+    />
+    <link rel="icon" href="/favicon.svg" />
+    <link rel="stylesheet" href="theme.hypermodern.css" />
+  </head>
+  <body class="page-auth">
+    <main class="card u-card">
+      <header>
+        <h1>Digitale Visitekaart</h1>
+        <p class="muted">Demo-login, geen echte backend.</p>
+      </header>
+
+      <div class="tabs" role="tablist" aria-label="Aanmelden">
+        <button id="tabLogin" type="button" role="tab" aria-selected="true" aria-controls="panelLogin">
+          Inloggen
+        </button>
+        <button
+          id="tabRegister"
+          type="button"
+          role="tab"
+          aria-selected="false"
+          aria-controls="panelRegister"
+          tabindex="-1"
+        >
+          Account aanmaken
+        </button>
+      </div>
+
+      <section id="panelLogin" role="tabpanel" tabindex="0" aria-labelledby="tabLogin">
+        <form id="loginForm">
+          <div>
+            <label for="loginEmail">E-mail</label>
+            <input
+              id="loginEmail"
+              class="u-input"
+              name="email"
+              type="email"
+              autocomplete="email"
+              required
+            />
+          </div>
+          <div>
+            <label for="loginPassword">Wachtwoord</label>
+            <input
+              id="loginPassword"
+              class="u-input"
+              name="password"
+              type="password"
+              minlength="6"
+              autocomplete="current-password"
+              required
+            />
+          </div>
+          <button type="submit" class="u-btn u-btn--primary">Inloggen</button>
+        </form>
+      </section>
+
+      <section id="panelRegister" role="tabpanel" tabindex="0" aria-labelledby="tabRegister" hidden>
+        <form id="registerForm">
+          <div>
+            <label for="registerEmail">E-mail</label>
+            <input
+              id="registerEmail"
+              class="u-input"
+              name="email"
+              type="email"
+              autocomplete="email"
+              required
+            />
+          </div>
+          <div>
+            <label for="registerPassword">Wachtwoord</label>
+            <input
+              id="registerPassword"
+              class="u-input"
+              name="password"
+              type="password"
+              minlength="6"
+              autocomplete="new-password"
+              required
+            />
+          </div>
+          <button type="submit" class="u-btn u-btn--ghost">Account aanmaken</button>
+        </form>
+      </section>
+
+      <p class="info">We bewaren alleen jouw e-mailadres lokaal in je browser.</p>
+      <p id="statusMessage" class="status" role="status" aria-live="polite"></p>
+    </main>
+
+    <script>
+      const STORAGE_KEY_USER = 'user:email';
+
+      function switchTab(activeId) {
+        const tabs = [
+          { tab: document.getElementById('tabLogin'), panel: document.getElementById('panelLogin') },
+          { tab: document.getElementById('tabRegister'), panel: document.getElementById('panelRegister') },
+        ];
+
+        tabs.forEach(({ tab, panel }) => {
+          const isActive = tab.id === activeId;
+          tab.setAttribute('aria-selected', String(isActive));
+          tab.tabIndex = isActive ? 0 : -1;
+          panel.hidden = !isActive;
+        });
+
+        const activeTab = document.getElementById(activeId);
+        activeTab?.focus();
+      }
+
+      function handleSubmit(event) {
+        event.preventDefault();
+        const form = event.currentTarget;
+        const emailInput = form.querySelector('input[type="email"]');
+
+        if (!(emailInput instanceof HTMLInputElement)) {
+          return;
+        }
+
+        const email = emailInput.value.trim();
+        if (!email) {
+          return;
+        }
+
+        try {
+          localStorage.setItem(STORAGE_KEY_USER, email);
+          window.location.href = 'index.html';
+        } catch (error) {
+          const status = document.getElementById('statusMessage');
+          if (status) {
+            status.textContent = 'Kon gegevens niet opslaan. Controleer je browserinstellingen.';
+          }
+          console.error('Kon user:email niet instellen', error);
+        }
+      }
+
+      document.getElementById('tabLogin')?.addEventListener('click', () => switchTab('tabLogin'));
+      document.getElementById('tabRegister')?.addEventListener('click', () => switchTab('tabRegister'));
+
+      document.getElementById('loginForm')?.addEventListener('submit', handleSubmit);
+      document.getElementById('registerForm')?.addEventListener('submit', handleSubmit);
+
+      if (localStorage.getItem(STORAGE_KEY_USER)) {
+        window.location.replace('index.html');
+      }
+    </script>
+  </body>
+</html>

--- a/mycard.html
+++ b/mycard.html
@@ -1,0 +1,254 @@
+<!doctype html>
+<html lang="nl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Digitale Visitekaart - Jouw kaart</title>
+    <meta name="description" content="Bekijk en deel je digitale visitekaart." />
+    <link rel="icon" href="./favicon.svg" />
+    <link rel="stylesheet" href="theme.hypermodern.css" />
+  </head>
+  <body class="page-card">
+    <div class="wrap container">
+      <section class="hero">
+        <div class="content">
+          <header>
+            <h1>Jouw digitale visitekaart</h1>
+            <p class="muted">Bekijk en deel je digitale visitekaart.</p>
+          </header>
+        </div>
+        <div class="actions hero-actions">
+          <a class="ghost-link u-btn u-btn--ghost" href="index.html">Terug naar editor</a>
+          <button id="shareBtn" class="u-btn u-btn--primary" type="button">Delen</button>
+          <button id="vcardBtn" class="u-btn u-btn--ghost" type="button">Download vCard</button>
+        </div>
+      </section>
+
+      <main>
+        <section id="cardView" class="card u-card" aria-live="polite" hidden>
+          <div class="preview">
+            <img id="cardAvatar" class="avatar" alt="Profielfoto" />
+            <div>
+              <div id="cardName" class="name"></div>
+              <div id="cardTitle" class="title" hidden></div>
+              <div id="cardCompany" class="company" hidden></div>
+              <div class="contact">
+                <a id="cardEmail" hidden></a>
+                <a id="cardPhone" hidden></a>
+                <a id="cardWebsite" hidden></a>
+                <a id="cardLinkedIn" hidden>LinkedIn</a>
+                <a id="cardInstagram" hidden>Instagram</a>
+                <a id="cardX" hidden>X</a>
+              </div>
+            </div>
+          </div>
+          <p id="cardTagline" class="tagline" hidden></p>
+        </section>
+
+        <section id="emptyState" class="card u-card empty" hidden>
+          <h2>Er is nog geen visitekaart</h2>
+          <p>Je hebt nog geen kaart opgeslagen op dit apparaat.</p>
+          <a class="ghost-link u-btn u-btn--ghost" href="index.html">Maak je kaart</a>
+        </section>
+      </main>
+    </div>
+
+    <script>
+      const STORAGE_KEY = 'card:data';
+      const PLACEHOLDER_AVATAR =
+        'data:image/svg+xml;utf8,' +
+        encodeURIComponent(
+          `<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96"><rect width="100%" height="100%" fill="#0f1218"/><text x="50%" y="52%" dominant-baseline="middle" text-anchor="middle" fill="#2e3440" font-family="Arial" font-size="12">Foto</text></svg>`
+        );
+
+      function withProtocol(url) {
+        if (!url) return '';
+        if (/^(https?:|data:|blob:)/i.test(url)) return url;
+        return `https://${url}`;
+      }
+
+      function load() {
+        try {
+          const raw = localStorage.getItem(STORAGE_KEY);
+          if (!raw) return undefined;
+          return JSON.parse(raw);
+        } catch (error) {
+          console.warn('Kon kaartdata niet laden', error);
+          return undefined;
+        }
+      }
+
+      function setTextContent(element, value) {
+        if (!element) return;
+        if (value) {
+          element.textContent = value;
+          element.hidden = false;
+        } else {
+          element.textContent = '';
+          element.hidden = true;
+        }
+      }
+
+      function renderCard(data) {
+        const card = document.getElementById('cardView');
+        const empty = document.getElementById('emptyState');
+        if (!card || !empty) return;
+
+        empty.hidden = true;
+        card.hidden = false;
+
+        const avatar = document.getElementById('cardAvatar');
+        if (avatar instanceof HTMLImageElement) {
+          avatar.src = withProtocol(data.avatar) || PLACEHOLDER_AVATAR;
+        }
+
+        setTextContent(document.getElementById('cardName'), data.name || '');
+        setTextContent(document.getElementById('cardTitle'), data.title || '');
+        setTextContent(document.getElementById('cardCompany'), data.company || '');
+        setTextContent(document.getElementById('cardTagline'), data.bio || '');
+
+        const emailLink = document.getElementById('cardEmail');
+        if (emailLink instanceof HTMLAnchorElement) {
+          if (data.email) {
+            emailLink.href = `mailto:${data.email}`;
+            emailLink.textContent = data.email;
+            emailLink.hidden = false;
+          } else {
+            emailLink.removeAttribute('href');
+            emailLink.hidden = true;
+          }
+        }
+
+        const telLink = document.getElementById('cardPhone');
+        if (telLink instanceof HTMLAnchorElement) {
+          if (data.phone) {
+            telLink.href = `tel:${data.phone}`;
+            telLink.textContent = data.phone;
+            telLink.hidden = false;
+          } else {
+            telLink.removeAttribute('href');
+            telLink.hidden = true;
+          }
+        }
+
+        const webLink = document.getElementById('cardWebsite');
+        if (webLink instanceof HTMLAnchorElement) {
+          if (data.website) {
+            const safeWebsite = withProtocol(data.website);
+            webLink.href = safeWebsite;
+            webLink.textContent = data.website;
+            webLink.target = '_blank';
+            webLink.rel = 'noreferrer';
+            webLink.hidden = false;
+          } else {
+            webLink.removeAttribute('href');
+            webLink.hidden = true;
+          }
+        }
+
+        const liLink = document.getElementById('cardLinkedIn');
+        if (liLink instanceof HTMLAnchorElement) {
+          if (data.linkedin) {
+            liLink.href = withProtocol(data.linkedin);
+            liLink.hidden = false;
+          } else {
+            liLink.removeAttribute('href');
+            liLink.hidden = true;
+          }
+        }
+
+        const igLink = document.getElementById('cardInstagram');
+        if (igLink instanceof HTMLAnchorElement) {
+          if (data.instagram) {
+            igLink.href = withProtocol(data.instagram);
+            igLink.hidden = false;
+          } else {
+            igLink.removeAttribute('href');
+            igLink.hidden = true;
+          }
+        }
+
+        const xLink = document.getElementById('cardX');
+        if (xLink instanceof HTMLAnchorElement) {
+          if (data.x) {
+            xLink.href = withProtocol(data.x);
+            xLink.hidden = false;
+          } else {
+            xLink.removeAttribute('href');
+            xLink.hidden = true;
+          }
+        }
+      }
+
+      function renderEmptyState() {
+        const card = document.getElementById('cardView');
+        const empty = document.getElementById('emptyState');
+        if (!card || !empty) return;
+
+        card.hidden = true;
+        empty.hidden = false;
+      }
+
+      function hydrate() {
+        const data = load();
+        if (!data) {
+          renderEmptyState();
+          return;
+        }
+
+        renderCard(data);
+      }
+
+      document.getElementById('shareBtn')?.addEventListener('click', () => {
+        const data = load();
+        if (!data) return;
+
+        const shareData = {
+          title: data.name || 'Mijn visitekaart',
+          text: data.bio || 'Bekijk mijn digitale visitekaart',
+          url: window.location.href,
+        };
+
+        if (navigator.share) {
+          navigator.share(shareData).catch((error) => {
+            console.warn('Delen geannuleerd', error);
+          });
+        } else {
+          navigator.clipboard
+            ?.writeText(`${shareData.title} - ${shareData.text} - ${shareData.url}`)
+            .catch((error) => console.warn('Kon kaart niet kopiëren', error));
+        }
+      });
+
+      document.getElementById('vcardBtn')?.addEventListener('click', () => {
+        const data = load();
+        if (!data) return;
+
+        const lines = [
+          'BEGIN:VCARD',
+          'VERSION:3.0',
+          `FN:${data.name || ''}`,
+          data.company ? `ORG:${data.company}` : null,
+          data.title ? `TITLE:${data.title}` : null,
+          data.phone ? `TEL;TYPE=CELL:${data.phone}` : null,
+          data.email ? `EMAIL;TYPE=WORK:${data.email}` : null,
+          data.website ? `URL:${withProtocol(data.website)}` : null,
+          data.linkedin ? `X-SOCIALPROFILE;TYPE=LinkedIn:${withProtocol(data.linkedin)}` : null,
+          data.instagram ? `X-SOCIALPROFILE;TYPE=Instagram:${withProtocol(data.instagram)}` : null,
+          data.x ? `X-SOCIALPROFILE;TYPE=X:${withProtocol(data.x)}` : null,
+          data.bio ? `NOTE:${data.bio}` : null,
+          'END:VCARD',
+        ].filter(Boolean);
+
+        const blob = new Blob([lines.join('\n')], { type: 'text/vcard' });
+        const link = document.createElement('a');
+        link.href = URL.createObjectURL(blob);
+        link.download = 'visitekaart.vcf';
+        link.click();
+        URL.revokeObjectURL(link.href);
+      });
+
+      hydrate();
+    </script>
+  </body>
+</html>

--- a/theme.hypermodern.css
+++ b/theme.hypermodern.css
@@ -1,0 +1,566 @@
+:root {
+  color-scheme: dark;
+  --gradient-start: #071531;
+  --gradient-end: #3b0f5f;
+  --surface-glass: rgba(14, 24, 48, 0.55);
+  --surface-glass-strong: rgba(28, 36, 64, 0.75);
+  --text-primary: #f5f7ff;
+  --text-muted: #9ea9d1;
+  --accent: #6c8cff;
+  --accent-glow: rgba(108, 140, 255, 0.55);
+  --ghost-border: rgba(156, 174, 255, 0.32);
+  --outline: rgba(120, 168, 255, 0.55);
+  --shadow-lg: 0 24px 60px rgba(6, 12, 40, 0.6);
+  --shadow-sm: 0 8px 32px rgba(8, 16, 40, 0.35);
+  --radius-card: 28px;
+  --radius-btn: 18px;
+  --transition: 180ms ease;
+  --font-sans: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Arial, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  line-height: 1.65;
+  color: var(--text-primary);
+  background: radial-gradient(circle at top right, rgba(90, 60, 180, 0.25), transparent 45%),
+    radial-gradient(circle at 10% 10%, rgba(90, 160, 255, 0.3), transparent 40%),
+    linear-gradient(135deg, var(--gradient-start), var(--gradient-end));
+  min-height: 100vh;
+  position: relative;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background: linear-gradient(160deg, rgba(17, 25, 47, 0.65), rgba(10, 8, 25, 0.35));
+  pointer-events: none;
+  z-index: -1;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+  transition: color var(--transition), text-shadow var(--transition);
+}
+
+a:hover,
+a:focus-visible {
+  color: #a6b6ff;
+  text-shadow: 0 0 12px rgba(166, 182, 255, 0.55);
+}
+
+a:focus-visible,
+button:focus-visible,
+.u-btn:focus-visible,
+.u-input:focus-visible {
+  outline: 2px solid var(--outline);
+  outline-offset: 3px;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.container {
+  width: min(1180px, calc(100% - 3.5rem));
+  margin-inline: auto;
+}
+
+.u-navbar {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  backdrop-filter: blur(18px);
+  background: linear-gradient(120deg, rgba(18, 26, 49, 0.78), rgba(16, 22, 38, 0.65));
+  border-bottom: 1px solid rgba(134, 156, 255, 0.12);
+  box-shadow: 0 12px 40px rgba(8, 10, 30, 0.45);
+}
+
+.u-navbar .inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1rem 0.5rem;
+  width: min(1180px, calc(100% - 3.5rem));
+  margin-inline: auto;
+}
+
+.site-brand a {
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  font-size: 1.1rem;
+  color: var(--text-primary);
+}
+
+.site-nav {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.site-nav a {
+  font-size: 0.9rem;
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  color: var(--text-muted);
+  transition: background var(--transition), color var(--transition), box-shadow var(--transition);
+}
+
+.site-nav a:hover,
+.site-nav a:focus-visible {
+  color: var(--text-primary);
+  background: rgba(122, 150, 255, 0.18);
+  box-shadow: 0 0 18px rgba(122, 150, 255, 0.35);
+}
+
+.hero {
+  position: relative;
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+  align-items: center;
+  padding: clamp(3rem, 7vw, 5rem) 0;
+  min-height: clamp(480px, 72vh, 720px);
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: var(--radius-card);
+  background: radial-gradient(circle at 15% 25%, rgba(108, 140, 255, 0.25), transparent 65%);
+  filter: blur(0px);
+  pointer-events: none;
+}
+
+.hero > * {
+  position: relative;
+  z-index: 1;
+}
+
+.hero .content {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.hero .content h1 {
+  font-size: clamp(2.5rem, 4vw, 3.5rem);
+  line-height: 1.1;
+  margin: 0;
+}
+
+.hero .content p {
+  margin: 0;
+  font-size: 1.05rem;
+  color: var(--text-muted);
+  max-width: 46ch;
+}
+
+.hero .actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 1rem;
+}
+
+.u-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  padding: 0.85rem 1.4rem;
+  border-radius: var(--radius-btn);
+  border: 1px solid transparent;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-primary);
+  cursor: pointer;
+  text-decoration: none;
+  transition: transform var(--transition), box-shadow var(--transition), background var(--transition), border-color var(--transition);
+}
+
+.u-btn:active {
+  transform: translateY(1px) scale(0.99);
+}
+
+.u-btn--primary {
+  background: linear-gradient(135deg, rgba(104, 140, 255, 0.95), rgba(186, 119, 255, 0.92));
+  border-color: rgba(180, 210, 255, 0.45);
+  color: #060815;
+  box-shadow: 0 18px 40px rgba(98, 142, 255, 0.45), 0 0 18px var(--accent-glow);
+}
+
+.u-btn--primary::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow: 0 0 35px 8px var(--accent-glow);
+  opacity: 0;
+  transition: opacity var(--transition);
+  pointer-events: none;
+}
+
+.u-btn--primary:hover,
+.u-btn--primary:focus-visible {
+  box-shadow: 0 20px 44px rgba(98, 142, 255, 0.6), 0 0 24px var(--accent-glow);
+}
+
+.u-btn--primary:hover::after,
+.u-btn--primary:focus-visible::after {
+  opacity: 1;
+}
+
+.u-btn--ghost {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: var(--ghost-border);
+  color: var(--text-primary);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.u-btn--ghost:hover,
+.u-btn--ghost:focus-visible {
+  background: rgba(140, 160, 255, 0.12);
+  border-color: rgba(196, 214, 255, 0.45);
+}
+
+.u-card {
+  background: linear-gradient(160deg, var(--surface-glass), rgba(20, 32, 58, 0.75));
+  border: 1px solid rgba(142, 162, 255, 0.12);
+  border-radius: var(--radius-card);
+  padding: clamp(1.75rem, 4vw, 2.5rem);
+  box-shadow: var(--shadow-lg);
+  backdrop-filter: blur(22px);
+  transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition);
+}
+
+.u-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 32px 80px rgba(8, 14, 40, 0.55);
+  border-color: rgba(186, 208, 255, 0.24);
+}
+
+.u-input {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(126, 146, 210, 0.22);
+  background: rgba(12, 18, 35, 0.9);
+  color: var(--text-primary);
+  font: inherit;
+  transition: border-color var(--transition), box-shadow var(--transition), background var(--transition);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+}
+
+textarea.u-input {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.u-input:hover {
+  border-color: rgba(170, 188, 255, 0.5);
+}
+
+.u-input:focus,
+.u-input:focus-visible {
+  border-color: rgba(180, 200, 255, 0.75);
+  box-shadow: 0 0 0 4px rgba(120, 168, 255, 0.2);
+  background: rgba(18, 28, 50, 0.95);
+}
+
+label {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  margin-bottom: 0.4rem;
+  display: inline-block;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.editor-main,
+main {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.grid {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.grid.cols-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+@media (max-width: 960px) {
+  .hero {
+    grid-template-columns: 1fr;
+    text-align: left;
+  }
+
+  .hero .actions {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 720px) {
+  .container {
+    width: calc(100% - 2.5rem);
+  }
+
+  .hero {
+    padding: 3rem 0 2rem;
+    min-height: auto;
+  }
+
+  .grid.cols-2 {
+    grid-template-columns: 1fr;
+  }
+
+  .hero .actions {
+    width: 100%;
+  }
+}
+
+.preview {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: minmax(96px, 120px) minmax(0, 1fr);
+  align-items: center;
+}
+
+.avatar {
+  width: 110px;
+  height: 110px;
+  border-radius: 26px;
+  object-fit: cover;
+  border: 1px solid rgba(180, 200, 255, 0.2);
+  background: rgba(12, 20, 40, 0.85);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.name {
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.title,
+.company,
+.muted {
+  color: var(--text-muted);
+}
+
+.contact {
+  display: grid;
+  gap: 0.45rem;
+  margin-top: 0.75rem;
+}
+
+.contact a {
+  color: var(--text-primary);
+  font-size: 0.95rem;
+  word-break: break-word;
+  padding-bottom: 0.2rem;
+  border-bottom: 1px dashed rgba(160, 180, 255, 0.24);
+}
+
+.contact a:hover,
+.contact a:focus-visible {
+  color: #d7deff;
+  border-bottom-color: rgba(215, 222, 255, 0.6);
+}
+
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  background: rgba(116, 136, 220, 0.2);
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.notice {
+  padding: 1rem 1.25rem;
+  border-radius: 18px;
+  background: rgba(92, 110, 196, 0.18);
+  border: 1px solid rgba(126, 150, 240, 0.25);
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.editor-footer,
+.u-footer {
+  margin-top: clamp(2rem, 5vw, 3.5rem);
+  padding: 1.5rem 0 2.5rem;
+  text-align: center;
+  color: var(--text-muted);
+  border-top: 1px solid rgba(150, 170, 255, 0.14);
+  background: linear-gradient(180deg, rgba(12, 18, 34, 0.35), rgba(8, 10, 25, 0.45));
+  backdrop-filter: blur(16px);
+}
+
+.page-dashboard .page-content {
+  padding: clamp(2rem, 5vw, 3.5rem) 0 4rem;
+}
+
+.page-dashboard .editor-wrap {
+  display: grid;
+  gap: clamp(2rem, 4vw, 3.5rem);
+}
+
+.page-dashboard .editor-main {
+  margin-top: 0;
+}
+
+.page-dashboard .editor-main > section {
+  position: relative;
+}
+
+.page-dashboard .editor-main > section::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  box-shadow: inset 0 0 0 1px rgba(180, 202, 255, 0.08);
+}
+
+.page-auth {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(3rem, 8vw, 5rem) 1.5rem;
+}
+
+.page-auth main {
+  width: min(100%, 440px);
+}
+
+.tabs {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+  background: rgba(18, 28, 52, 0.9);
+  border-radius: 18px;
+  padding: 0.4rem;
+  border: 1px solid rgba(146, 168, 250, 0.25);
+}
+
+.tabs button {
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  padding: 0.75rem 0.9rem;
+  border-radius: 14px;
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition), box-shadow var(--transition);
+}
+
+.tabs button[aria-selected='true'] {
+  background: rgba(132, 152, 250, 0.25);
+  color: var(--text-primary);
+  box-shadow: inset 0 0 0 1px rgba(170, 190, 255, 0.4);
+}
+
+.info {
+  text-align: center;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.status {
+  min-height: 1.2em;
+  text-align: center;
+  color: var(--accent);
+  font-size: 0.9rem;
+}
+
+.wrap {
+  width: min(960px, calc(100% - 3.5rem));
+  margin-inline: auto;
+  padding: clamp(2.5rem, 6vw, 4rem) 0 clamp(3rem, 7vw, 5rem);
+  display: grid;
+  gap: clamp(2rem, 4vw, 3rem);
+}
+
+.wrap header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.wrap .actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.ghost-link {
+  color: var(--text-muted);
+}
+
+.empty {
+  text-align: center;
+  display: grid;
+  gap: 1rem;
+}
+
+.tagline {
+  font-size: 1.05rem;
+  color: var(--text-muted);
+}
+
+@media (max-width: 640px) {
+  .preview {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .preview .contact {
+    justify-items: center;
+  }
+
+  .hero .content,
+  .hero .actions {
+    justify-items: center;
+    text-align: center;
+  }
+
+  .hero .actions {
+    justify-content: center;
+  }
+
+  .wrap header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable hypermodern theme stylesheet with gradient background, glass UI blocks, CTA buttons and form helpers
- restyle the dashboard, login and card pages to use the new hero layout, floating cards and updated buttons/inputs while preserving existing IDs and scripts
- link the standalone index.html to the shared theme stylesheet

## Testing
- not run (static files only)


------
https://chatgpt.com/codex/tasks/task_e_68c970e3de1c8327892bab1ade4e917e