### PR TITLE
Fix hypermodern look: CSS last-link + classes + redirects

### DIFF
--- a/404.html
+++ b/404.html
@@ -10,26 +10,29 @@
     />
     <link rel="icon" href="./favicon.svg" />
     <link rel="stylesheet" href="./styles.css" />
+    <link rel="stylesheet" href="theme.hypermodern.css?v=3" />
   </head>
   <body>
-    <header class="site-header">
-      <div class="site-brand">
-        <a href="./index.html">Digitale Visitekaart</a>
+    <header class="site-header u-navbar">
+      <div class="inner container">
+        <div class="site-brand">
+          <a href="./index.html">Digitale Visitekaart</a>
+        </div>
+        <nav class="site-nav" aria-label="Hoofdmenu">
+          <a href="./index.html">Start</a>
+          <a href="./profile.html">Profiel</a>
+          <a href="./card.html">Kaart</a>
+          <a href="./dashboard.html">Dashboard</a>
+          <a href="./settings.html">Instellingen</a>
+          <a href="./privacy.html">Privacy</a>
+          <a href="./terms.html">Voorwaarden</a>
+          <a href="./cookies.html">Cookies</a>
+        </nav>
       </div>
-      <nav class="site-nav" aria-label="Hoofdmenu">
-        <a href="./index.html">Start</a>
-        <a href="./profile.html">Profiel</a>
-        <a href="./card.html">Kaart</a>
-        <a href="./dashboard.html">Dashboard</a>
-        <a href="./settings.html">Instellingen</a>
-        <a href="./privacy.html">Privacy</a>
-        <a href="./terms.html">Voorwaarden</a>
-        <a href="./cookies.html">Cookies</a>
-      </nav>
     </header>
 
-    <div class="page-content">
-      <main class="info-card card text-center">
+    <div class="page-content container">
+      <main class="info-card card text-center u-card">
         <h1>Pagina niet gevonden</h1>
         <p>Deze pagina bestaat niet. Ga terug naar <a href="./index.html">de start</a>.</p>
       </main>

--- a/card.html
+++ b/card.html
@@ -7,37 +7,40 @@
     <meta name="description" content="Bekijk en deel je digitale visitekaart." />
     <link rel="icon" href="./favicon.svg" />
     <link rel="stylesheet" href="./styles.css" />
+    <link rel="stylesheet" href="theme.hypermodern.css?v=3" />
   </head>
   <body class="card-page" data-page="card">
-    <header class="site-header">
-      <div class="site-brand">
-        <a href="./index.html">Digitale Visitekaart</a>
+    <header class="site-header u-navbar">
+      <div class="inner container">
+        <div class="site-brand">
+          <a href="./index.html">Digitale Visitekaart</a>
+        </div>
+        <nav class="site-nav" aria-label="Hoofdmenu">
+          <a href="./index.html">Start</a>
+          <a href="./profile.html">Profiel</a>
+          <a href="./card.html">Kaart</a>
+          <a href="./dashboard.html">Dashboard</a>
+          <a href="./settings.html">Instellingen</a>
+          <a href="./privacy.html">Privacy</a>
+          <a href="./terms.html">Voorwaarden</a>
+          <a href="./cookies.html">Cookies</a>
+        </nav>
       </div>
-      <nav class="site-nav" aria-label="Hoofdmenu">
-        <a href="./index.html">Start</a>
-        <a href="./profile.html">Profiel</a>
-        <a href="./card.html">Kaart</a>
-        <a href="./dashboard.html">Dashboard</a>
-        <a href="./settings.html">Instellingen</a>
-        <a href="./privacy.html">Privacy</a>
-        <a href="./terms.html">Voorwaarden</a>
-        <a href="./cookies.html">Cookies</a>
-      </nav>
     </header>
 
-    <div class="page-content">
+    <div class="page-content container">
       <div class="page-inner">
         <header>
           <h1>Jouw digitale visitekaart</h1>
           <div class="actions">
-            <a class="ghost-link" href="./dashboard.html">Terug naar editor</a>
-            <button id="shareBtn" type="button">Delen</button>
-            <button id="vcardBtn" type="button">Download vCard</button>
+            <a class="ghost-link u-btn u-btn--ghost" href="./dashboard.html">Terug naar editor</a>
+            <button id="shareBtn" type="button" class="u-btn u-btn--primary">Delen</button>
+            <button id="vcardBtn" type="button" class="u-btn u-btn--primary">Download vCard</button>
           </div>
         </header>
 
         <main>
-          <section id="cardView" class="card" aria-live="polite" hidden>
+          <section id="cardView" class="card u-card" aria-live="polite" hidden>
             <div class="preview">
               <img id="cardAvatar" class="avatar" alt="Profielfoto" />
               <div>
@@ -57,10 +60,10 @@
             <p id="cardTagline" class="tagline" hidden></p>
           </section>
 
-          <section id="emptyState" class="card empty" hidden>
+          <section id="emptyState" class="card empty u-card" hidden>
             <h2>Er is nog geen visitekaart</h2>
             <p>Je hebt nog geen kaart opgeslagen op dit apparaat.</p>
-            <a class="ghost-link" href="./dashboard.html">Maak je kaart</a>
+            <a class="ghost-link u-btn u-btn--ghost" href="./dashboard.html">Maak je kaart</a>
           </section>
         </main>
       </div>

--- a/cookies.html
+++ b/cookies.html
@@ -10,26 +10,29 @@
     />
     <link rel="icon" href="./favicon.svg" />
     <link rel="stylesheet" href="./styles.css" />
+    <link rel="stylesheet" href="theme.hypermodern.css?v=3" />
   </head>
   <body>
-    <header class="site-header">
-      <div class="site-brand">
-        <a href="./index.html">Digitale Visitekaart</a>
+    <header class="site-header u-navbar">
+      <div class="inner container">
+        <div class="site-brand">
+          <a href="./index.html">Digitale Visitekaart</a>
+        </div>
+        <nav class="site-nav" aria-label="Hoofdmenu">
+          <a href="./index.html">Start</a>
+          <a href="./profile.html">Profiel</a>
+          <a href="./card.html">Kaart</a>
+          <a href="./dashboard.html">Dashboard</a>
+          <a href="./settings.html">Instellingen</a>
+          <a href="./privacy.html">Privacy</a>
+          <a href="./terms.html">Voorwaarden</a>
+          <a href="./cookies.html">Cookies</a>
+        </nav>
       </div>
-      <nav class="site-nav" aria-label="Hoofdmenu">
-        <a href="./index.html">Start</a>
-        <a href="./profile.html">Profiel</a>
-        <a href="./card.html">Kaart</a>
-        <a href="./dashboard.html">Dashboard</a>
-        <a href="./settings.html">Instellingen</a>
-        <a href="./privacy.html">Privacy</a>
-        <a href="./terms.html">Voorwaarden</a>
-        <a href="./cookies.html">Cookies</a>
-      </nav>
     </header>
 
-    <div class="page-content">
-      <main class="info-card card">
+    <div class="page-content container">
+      <main class="info-card card u-card">
         <h1>Cookies &amp; lokale opslag</h1>
         <p>
           Deze site gebruikt geen trackingcookies. Om je voortgang te bewaren, slaan we gegevens op in <em>localStorage</em> van je

--- a/dashboard.html
+++ b/dashboard.html
@@ -10,11 +10,11 @@
     />
     <link rel="icon" href="./favicon.svg" />
     <link rel="stylesheet" href="./styles.css" />
-    <link rel="stylesheet" href="theme.hypermodern.css?v=2" />
+    <link rel="stylesheet" href="theme.hypermodern.css?v=3" />
   </head>
   <body class="page-dashboard" data-page="dashboard">
     <header class="site-header u-navbar">
-      <div class="inner">
+      <div class="inner container">
         <div class="site-brand">
           <a href="./index.html">Digitale Visitekaart</a>
         </div>
@@ -162,7 +162,7 @@
           </section>
         </main>
 
-        <footer class="editor-footer">
+        <footer class="editor-footer u-footer">
           Bewaar je wijzigingen lokaal en deel je kaart. De AI-functie gebruikt het serverless endpoint met
           <code>OPENAI_API_KEY</code>.
         </footer>

--- a/index.html
+++ b/index.html
@@ -10,26 +10,29 @@
     />
     <link rel="icon" href="./favicon.svg" />
     <link rel="stylesheet" href="./styles.css" />
+    <link rel="stylesheet" href="theme.hypermodern.css?v=3" />
   </head>
   <body class="page-auth" data-page="auth">
-    <header class="site-header">
-      <div class="site-brand">
-        <a href="./index.html">Digitale Visitekaart</a>
+    <header class="site-header u-navbar">
+      <div class="inner container">
+        <div class="site-brand">
+          <a href="./index.html">Digitale Visitekaart</a>
+        </div>
+        <nav class="site-nav" aria-label="Hoofdmenu">
+          <a href="./index.html">Start</a>
+          <a href="./profile.html">Profiel</a>
+          <a href="./card.html">Kaart</a>
+          <a href="./dashboard.html">Dashboard</a>
+          <a href="./settings.html">Instellingen</a>
+          <a href="./privacy.html">Privacy</a>
+          <a href="./terms.html">Voorwaarden</a>
+          <a href="./cookies.html">Cookies</a>
+        </nav>
       </div>
-      <nav class="site-nav" aria-label="Hoofdmenu">
-        <a href="./index.html">Start</a>
-        <a href="./profile.html">Profiel</a>
-        <a href="./card.html">Kaart</a>
-        <a href="./dashboard.html">Dashboard</a>
-        <a href="./settings.html">Instellingen</a>
-        <a href="./privacy.html">Privacy</a>
-        <a href="./terms.html">Voorwaarden</a>
-        <a href="./cookies.html">Cookies</a>
-      </nav>
     </header>
 
-    <div class="page-content">
-      <main class="auth-card" aria-labelledby="authTitle">
+    <div class="page-content container">
+      <main class="auth-card u-card" aria-labelledby="authTitle">
         <header>
           <h1 id="authTitle">Digitale Visitekaart</h1>
           <p class="muted">
@@ -38,7 +41,14 @@
         </header>
 
         <div class="tabs" role="tablist" aria-label="Aanmelden">
-          <button id="tabLogin" type="button" role="tab" aria-selected="true" aria-controls="panelLogin">
+          <button
+            id="tabLogin"
+            type="button"
+            role="tab"
+            aria-selected="true"
+            aria-controls="panelLogin"
+            class="u-btn u-btn--ghost"
+          >
             Inloggen
           </button>
           <button
@@ -48,6 +58,7 @@
             aria-selected="false"
             aria-controls="panelRegister"
             tabindex="-1"
+            class="u-btn u-btn--ghost"
           >
             Account aanmaken
           </button>
@@ -57,7 +68,7 @@
           <form id="loginForm" autocomplete="on">
             <div class="form-field">
               <label for="loginEmail">E-mailadres</label>
-              <input id="loginEmail" name="email" type="email" autocomplete="email" required />
+              <input id="loginEmail" name="email" type="email" autocomplete="email" required class="u-input" />
             </div>
             <div class="form-field">
               <label for="loginPassword">Wachtwoord</label>
@@ -68,9 +79,10 @@
                 minlength="6"
                 autocomplete="current-password"
                 required
+                class="u-input"
               />
             </div>
-            <button type="submit">Inloggen</button>
+            <button type="submit" class="u-btn u-btn--primary">Inloggen</button>
           </form>
         </section>
 
@@ -78,7 +90,7 @@
           <form id="registerForm" autocomplete="on">
             <div class="form-field">
               <label for="registerEmail">E-mailadres</label>
-              <input id="registerEmail" name="email" type="email" autocomplete="email" required />
+              <input id="registerEmail" name="email" type="email" autocomplete="email" required class="u-input" />
             </div>
             <div class="form-field">
               <label for="registerPassword">Wachtwoord</label>
@@ -89,9 +101,10 @@
                 minlength="6"
                 autocomplete="new-password"
                 required
+                class="u-input"
               />
             </div>
-            <button type="submit">Account aanmaken</button>
+            <button type="submit" class="u-btn u-btn--primary">Account aanmaken</button>
           </form>
         </section>
 

--- a/privacy.html
+++ b/privacy.html
@@ -10,26 +10,29 @@
     />
     <link rel="icon" href="./favicon.svg" />
     <link rel="stylesheet" href="./styles.css" />
+    <link rel="stylesheet" href="theme.hypermodern.css?v=3" />
   </head>
   <body>
-    <header class="site-header">
-      <div class="site-brand">
-        <a href="./index.html">Digitale Visitekaart</a>
+    <header class="site-header u-navbar">
+      <div class="inner container">
+        <div class="site-brand">
+          <a href="./index.html">Digitale Visitekaart</a>
+        </div>
+        <nav class="site-nav" aria-label="Hoofdmenu">
+          <a href="./index.html">Start</a>
+          <a href="./profile.html">Profiel</a>
+          <a href="./card.html">Kaart</a>
+          <a href="./dashboard.html">Dashboard</a>
+          <a href="./settings.html">Instellingen</a>
+          <a href="./privacy.html">Privacy</a>
+          <a href="./terms.html">Voorwaarden</a>
+          <a href="./cookies.html">Cookies</a>
+        </nav>
       </div>
-      <nav class="site-nav" aria-label="Hoofdmenu">
-        <a href="./index.html">Start</a>
-        <a href="./profile.html">Profiel</a>
-        <a href="./card.html">Kaart</a>
-        <a href="./dashboard.html">Dashboard</a>
-        <a href="./settings.html">Instellingen</a>
-        <a href="./privacy.html">Privacy</a>
-        <a href="./terms.html">Voorwaarden</a>
-        <a href="./cookies.html">Cookies</a>
-      </nav>
     </header>
 
-    <div class="page-content">
-      <main class="info-card card">
+    <div class="page-content container">
+      <main class="info-card card u-card">
         <h1>Privacyverklaring</h1>
         <p>
           De digitale visitekaart werkt volledig client-side. Gegevens die je invult, zoals naam, contactgegevens of social media,

--- a/profile.html
+++ b/profile.html
@@ -10,26 +10,29 @@
     />
     <link rel="icon" href="./favicon.svg" />
     <link rel="stylesheet" href="./styles.css" />
+    <link rel="stylesheet" href="theme.hypermodern.css?v=3" />
   </head>
   <body>
-    <header class="site-header">
-      <div class="site-brand">
-        <a href="./index.html">Digitale Visitekaart</a>
+    <header class="site-header u-navbar">
+      <div class="inner container">
+        <div class="site-brand">
+          <a href="./index.html">Digitale Visitekaart</a>
+        </div>
+        <nav class="site-nav" aria-label="Hoofdmenu">
+          <a href="./index.html">Start</a>
+          <a href="./profile.html">Profiel</a>
+          <a href="./card.html">Kaart</a>
+          <a href="./dashboard.html">Dashboard</a>
+          <a href="./settings.html">Instellingen</a>
+          <a href="./privacy.html">Privacy</a>
+          <a href="./terms.html">Voorwaarden</a>
+          <a href="./cookies.html">Cookies</a>
+        </nav>
       </div>
-      <nav class="site-nav" aria-label="Hoofdmenu">
-        <a href="./index.html">Start</a>
-        <a href="./profile.html">Profiel</a>
-        <a href="./card.html">Kaart</a>
-        <a href="./dashboard.html">Dashboard</a>
-        <a href="./settings.html">Instellingen</a>
-        <a href="./privacy.html">Privacy</a>
-        <a href="./terms.html">Voorwaarden</a>
-        <a href="./cookies.html">Cookies</a>
-      </nav>
     </header>
 
-    <div class="page-content">
-      <main class="info-card card">
+    <div class="page-content container">
+      <main class="info-card card u-card">
         <h1>Jouw profiel</h1>
         <p>
           De digitale visitekaart bundelt je belangrijkste contactgegevens, sociale profielen en korte bio. Alles wat je hier

--- a/settings.html
+++ b/settings.html
@@ -10,26 +10,29 @@
     />
     <link rel="icon" href="./favicon.svg" />
     <link rel="stylesheet" href="./styles.css" />
+    <link rel="stylesheet" href="theme.hypermodern.css?v=3" />
   </head>
   <body>
-    <header class="site-header">
-      <div class="site-brand">
-        <a href="./index.html">Digitale Visitekaart</a>
+    <header class="site-header u-navbar">
+      <div class="inner container">
+        <div class="site-brand">
+          <a href="./index.html">Digitale Visitekaart</a>
+        </div>
+        <nav class="site-nav" aria-label="Hoofdmenu">
+          <a href="./index.html">Start</a>
+          <a href="./profile.html">Profiel</a>
+          <a href="./card.html">Kaart</a>
+          <a href="./dashboard.html">Dashboard</a>
+          <a href="./settings.html">Instellingen</a>
+          <a href="./privacy.html">Privacy</a>
+          <a href="./terms.html">Voorwaarden</a>
+          <a href="./cookies.html">Cookies</a>
+        </nav>
       </div>
-      <nav class="site-nav" aria-label="Hoofdmenu">
-        <a href="./index.html">Start</a>
-        <a href="./profile.html">Profiel</a>
-        <a href="./card.html">Kaart</a>
-        <a href="./dashboard.html">Dashboard</a>
-        <a href="./settings.html">Instellingen</a>
-        <a href="./privacy.html">Privacy</a>
-        <a href="./terms.html">Voorwaarden</a>
-        <a href="./cookies.html">Cookies</a>
-      </nav>
     </header>
 
-    <div class="page-content">
-      <main class="info-card card">
+    <div class="page-content container">
+      <main class="info-card card u-card">
         <h1>Instellingen en data</h1>
         <p>
           Alle informatie van je visitekaart wordt uitsluitend in de lokale opslag van je browser bewaard. Je kunt de gegevens

--- a/terms.html
+++ b/terms.html
@@ -10,26 +10,29 @@
     />
     <link rel="icon" href="./favicon.svg" />
     <link rel="stylesheet" href="./styles.css" />
+    <link rel="stylesheet" href="theme.hypermodern.css?v=3" />
   </head>
   <body>
-    <header class="site-header">
-      <div class="site-brand">
-        <a href="./index.html">Digitale Visitekaart</a>
+    <header class="site-header u-navbar">
+      <div class="inner container">
+        <div class="site-brand">
+          <a href="./index.html">Digitale Visitekaart</a>
+        </div>
+        <nav class="site-nav" aria-label="Hoofdmenu">
+          <a href="./index.html">Start</a>
+          <a href="./profile.html">Profiel</a>
+          <a href="./card.html">Kaart</a>
+          <a href="./dashboard.html">Dashboard</a>
+          <a href="./settings.html">Instellingen</a>
+          <a href="./privacy.html">Privacy</a>
+          <a href="./terms.html">Voorwaarden</a>
+          <a href="./cookies.html">Cookies</a>
+        </nav>
       </div>
-      <nav class="site-nav" aria-label="Hoofdmenu">
-        <a href="./index.html">Start</a>
-        <a href="./profile.html">Profiel</a>
-        <a href="./card.html">Kaart</a>
-        <a href="./dashboard.html">Dashboard</a>
-        <a href="./settings.html">Instellingen</a>
-        <a href="./privacy.html">Privacy</a>
-        <a href="./terms.html">Voorwaarden</a>
-        <a href="./cookies.html">Cookies</a>
-      </nav>
     </header>
 
-    <div class="page-content">
-      <main class="info-card card">
+    <div class="page-content container">
+      <main class="info-card card u-card">
         <h1>Gebruiksvoorwaarden</h1>
         <p>
           Deze demo helpt je een digitale visitekaart te maken en is bedoeld voor persoonlijk gebruik. Door de site te gebruiken

--- a/theme.hypermodern.css
+++ b/theme.hypermodern.css
@@ -31,8 +31,10 @@ img{max-width:100%; display:block}
 .u-navbar .inner{display:flex; align-items:center; justify-content:space-between; padding:14px 22px}
 
 /* Hero fullscreen */
-.hero{min-height:88vh; display:grid; place-items:center; padding:32px}
+.hero{min-height:88vh; display:grid; place-items:center; padding:32px; width:100%}
 .hero .content{max-width:960px; text-align:center}
+.hero .actions{display:flex; gap:16px; flex-wrap:wrap; justify-content:center; margin-top:32px}
+.hero .actions .u-btn{min-width:180px}
 h1{font-size:clamp(36px,7vw,64px); line-height:1.05; margin:0 0 10px}
 p.lead{color:var(--muted); font-size:clamp(16px,2.5vw,20px); margin:0}
 
@@ -47,6 +49,9 @@ p.lead{color:var(--muted); font-size:clamp(16px,2.5vw,20px); margin:0}
 .u-btn--primary:hover{transform:translateY(-2px)}
 .u-btn--ghost{background:transparent; color:#E6EAF2; border-color:rgba(255,255,255,.18)}
 .u-btn--ghost:hover{background:rgba(255,255,255,.05)}
+.tabs .u-btn{width:100%; justify-content:center}
+.tabs button.u-btn{background:rgba(255,255,255,.04); border-color:rgba(255,255,255,.12); color:#E6EAF2; padding:12px 16px}
+.tabs button.u-btn[aria-selected="true"]{background:rgba(59,130,246,.2); border-color:rgba(99,102,241,.35); color:#fff}
 
 /* Cards */
 .u-card{


### PR DESCRIPTION
## Summary
- ensure hypermodern theme loads last with version bump across HTML pages
- enhance dashboard, login, and informational pages with glass navbar, hero, cards, and button/input classes
- refine theme CSS for hero actions, button layouts, and tab styling for a consistent dark gradient aesthetic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9c9bef7048327abfcda91f9298c44