### PR TITLE
UI polish naar mockup + mobile-first nav/hero/grid

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -10,14 +10,14 @@
     />
     <link rel="icon" href="./favicon.svg" />
     <link rel="stylesheet" href="./styles.css" />
-    <link rel="stylesheet" href="theme.hypermodern.css?v=3" />
+    <link rel="stylesheet" href="theme.hypermodern.css?v=7">
   </head>
   <body class="page-dashboard" data-page="dashboard">
     <header class="site-header u-navbar">
-      <div class="inner container">
-        <div class="site-brand">
-          <a href="./index.html">Digitale Visitekaart</a>
-        </div>
+      <div class="inner">
+        <div class="brand"><a href="./index.html">Digitale Visitekaart</a></div>
+        <label for="nav-toggle" class="nav-btn">Menu</label>
+        <input id="nav-toggle" class="nav-toggle" type="checkbox" aria-label="Menu openen">
         <nav class="site-nav" aria-label="Hoofdmenu">
           <a href="./index.html">Start</a>
           <a href="./profile.html">Profiel</a>
@@ -32,141 +32,140 @@
     </header>
 
     <div class="page-content">
-      <div class="editor-wrap container">
-        <header class="editor-header">
-          <section class="hero">
-            <div class="content">
-              <h1>Digitale Visitekaart</h1>
-              <p class="muted">Bewerk je digitale visitekaart en deel hem met anderen.</p>
-            </div>
-            <div class="actions">
-              <button id="btnLogout" type="button" class="u-btn u-btn--ghost">Uitloggen</button>
-              <button id="btnShare" type="button" class="u-btn u-btn--primary">Delen</button>
-              <button id="btnVCard" type="button" class="u-btn u-btn--primary">Download vCard</button>
-            </div>
-          </section>
-        </header>
+      <section class="hero">
+        <div class="content">
+          <h1>Digitale Visitekaart</h1>
+          <p class="lead">Bewerk je digitale visitekaart en deel hem met anderen.</p>
+        </div>
+        <div class="actions">
+          <button id="btnLogout" type="button" class="u-btn u-btn--ghost">Uitloggen</button>
+          <button id="btnShare" type="button" class="u-btn u-btn--primary">Delen</button>
+          <button id="btnVCard" type="button" class="u-btn u-btn--primary">Download vCard</button>
+        </div>
+      </section>
+      <div class="container">
+        <div class="editor-wrap">
+          <main class="editor-main">
+            <section class="card u-card" aria-labelledby="previewTitle">
+              <h2 id="previewTitle" class="muted">Voorbeeldkaart</h2>
+              <div class="preview">
+                <img id="avatarPreview" class="avatar" alt="Profielfoto" />
+                <div>
+                  <div class="name" id="namePreview">Jouw Naam</div>
+                  <div class="title" id="titlePreview">Functie</div>
+                  <div class="company" id="companyPreview">Bedrijf</div>
+                  <div class="contact">
+                    <a href="#" id="emailLink" aria-disabled="true">E-mail</a>
+                    <a href="#" id="telLink" aria-disabled="true">Telefoon</a>
+                    <a href="#" id="webLink" aria-disabled="true">Website</a>
+                    <a href="#" id="liLink" aria-disabled="true">LinkedIn</a>
+                    <a href="#" id="igLink" aria-disabled="true">Instagram</a>
+                    <a href="#" id="xLink" aria-disabled="true">X</a>
+                  </div>
+                </div>
+              </div>
+              <p id="tagline"></p>
+            </section>
 
-        <main class="editor-main">
-          <section class="card u-card" aria-labelledby="previewTitle">
-            <h2 id="previewTitle" class="muted">Voorbeeldkaart</h2>
-            <div class="preview">
-              <img id="avatarPreview" class="avatar" alt="Profielfoto" />
-              <div>
-                <div class="name" id="namePreview">Jouw Naam</div>
-                <div class="title" id="titlePreview">Functie</div>
-                <div class="company" id="companyPreview">Bedrijf</div>
-                <div class="contact">
-                  <a href="#" id="emailLink" aria-disabled="true">E-mail</a>
-                  <a href="#" id="telLink" aria-disabled="true">Telefoon</a>
-                  <a href="#" id="webLink" aria-disabled="true">Website</a>
-                  <a href="#" id="liLink" aria-disabled="true">LinkedIn</a>
-                  <a href="#" id="igLink" aria-disabled="true">Instagram</a>
-                  <a href="#" id="xLink" aria-disabled="true">X</a>
+            <section class="card u-card" aria-labelledby="editTitle">
+              <h2 id="editTitle" class="muted">Bewerken</h2>
+              <form id="editForm">
+                <div class="grid cols-2">
+                  <div>
+                    <label for="fieldName">Naam</label>
+                    <input id="fieldName" name="name" class="u-input" placeholder="Jouw Naam" />
+                  </div>
+                  <div>
+                    <label for="fieldTitle">Functie</label>
+                    <input id="fieldTitle" name="title" class="u-input" placeholder="Bijv. Founder" />
+                  </div>
                 </div>
-              </div>
-            </div>
-            <p id="tagline"></p>
-          </section>
-
-          <section class="card u-card" aria-labelledby="editTitle">
-            <h2 id="editTitle" class="muted">Bewerken</h2>
-            <form id="editForm">
-              <div class="grid-2 grid cols-2">
-                <div>
-                  <label for="fieldName">Naam</label>
-                  <input id="fieldName" name="name" class="u-input" placeholder="Jouw Naam" />
+                <div class="grid cols-2">
+                  <div>
+                    <label for="fieldCompany">Bedrijf</label>
+                    <input id="fieldCompany" name="company" class="u-input" placeholder="Bedrijfsnaam" />
+                  </div>
+                  <div>
+                    <label for="fieldWebsite">Website</label>
+                    <input id="fieldWebsite" name="website" class="u-input" placeholder="https://..." />
+                  </div>
+                </div>
+                <div class="grid cols-2">
+                  <div>
+                    <label for="fieldEmail">E-mail</label>
+                    <input
+                      id="fieldEmail"
+                      name="email"
+                      type="email"
+                      class="u-input"
+                      placeholder="jij@voorbeeld.nl"
+                    />
+                  </div>
+                  <div>
+                    <label for="fieldPhone">Telefoon</label>
+                    <input id="fieldPhone" name="phone" class="u-input" placeholder="+31..." />
+                  </div>
+                </div>
+                <div class="grid cols-2">
+                  <div>
+                    <label for="fieldLinkedIn">LinkedIn</label>
+                    <input
+                      id="fieldLinkedIn"
+                      name="linkedin"
+                      class="u-input"
+                      placeholder="https://linkedin.com/in/..."
+                    />
+                  </div>
+                  <div>
+                    <label for="fieldInstagram">Instagram</label>
+                    <input
+                      id="fieldInstagram"
+                      name="instagram"
+                      class="u-input"
+                      placeholder="https://instagram.com/..."
+                    />
+                  </div>
+                </div>
+                <div class="grid cols-2">
+                  <div>
+                    <label for="fieldX">X (Twitter)</label>
+                    <input id="fieldX" name="x" class="u-input" placeholder="https://x.com/..." />
+                  </div>
+                  <div aria-hidden="true"></div>
                 </div>
                 <div>
-                  <label for="fieldTitle">Functie</label>
-                  <input id="fieldTitle" name="title" class="u-input" placeholder="Bijv. Founder" />
-                </div>
-              </div>
-              <div class="grid-2 grid cols-2">
-                <div>
-                  <label for="fieldCompany">Bedrijf</label>
-                  <input id="fieldCompany" name="company" class="u-input" placeholder="Bedrijfsnaam" />
+                  <label for="fieldAvatar">Profielfoto (URL)</label>
+                  <input id="fieldAvatar" name="avatar" class="u-input" placeholder="https://...jpg" />
                 </div>
                 <div>
-                  <label for="fieldWebsite">Website</label>
-                  <input id="fieldWebsite" name="website" class="u-input" placeholder="https://..." />
-                </div>
-              </div>
-              <div class="grid-2 grid cols-2">
-                <div>
-                  <label for="fieldEmail">E-mail</label>
-                  <input
-                    id="fieldEmail"
-                    name="email"
-                    type="email"
+                  <label for="fieldBio">Korte bio / tagline</label>
+                  <textarea
+                    id="fieldBio"
+                    name="bio"
+                    rows="3"
                     class="u-input"
-                    placeholder="jij@voorbeeld.nl"
-                  />
+                    placeholder="Wat doe jij?"
+                  ></textarea>
                 </div>
-                <div>
-                  <label for="fieldPhone">Telefoon</label>
-                  <input id="fieldPhone" name="phone" class="u-input" placeholder="+31..." />
+                <div class="row">
+                  <button id="btnGenerate" type="button" class="u-btn u-btn--primary">
+                    Genereer tagline met AI
+                  </button>
+                  <span class="pill">OpenAI-sleutel vereist</span>
                 </div>
+              </form>
+              <div class="notice" role="status">
+                Configureer het endpoint <code>/api/generate</code> met een OpenAI-sleutel om automatisch een tagline te genereren.
               </div>
-              <div class="grid-2 grid cols-2">
-                <div>
-                  <label for="fieldLinkedIn">LinkedIn</label>
-                  <input
-                    id="fieldLinkedIn"
-                    name="linkedin"
-                    class="u-input"
-                    placeholder="https://linkedin.com/in/..."
-                  />
-                </div>
-                <div>
-                  <label for="fieldInstagram">Instagram</label>
-                  <input
-                    id="fieldInstagram"
-                    name="instagram"
-                    class="u-input"
-                    placeholder="https://instagram.com/..."
-                  />
-                </div>
-              </div>
-              <div class="grid-2 grid cols-2">
-                <div>
-                  <label for="fieldX">X (Twitter)</label>
-                  <input id="fieldX" name="x" class="u-input" placeholder="https://x.com/..." />
-                </div>
-                <div aria-hidden="true"></div>
-              </div>
-              <div>
-                <label for="fieldAvatar">Profielfoto (URL)</label>
-                <input id="fieldAvatar" name="avatar" class="u-input" placeholder="https://...jpg" />
-              </div>
-              <div>
-                <label for="fieldBio">Korte bio / tagline</label>
-                <textarea
-                  id="fieldBio"
-                  name="bio"
-                  rows="3"
-                  class="u-input"
-                  placeholder="Wat doe jij?"
-                ></textarea>
-              </div>
-              <div class="row">
-                <button id="btnGenerate" type="button" class="u-btn u-btn--primary">
-                  Genereer tagline met AI
-                </button>
-                <span class="pill">OpenAI-sleutel vereist</span>
-              </div>
-            </form>
-            <div class="notice" role="status">
-              Configureer het endpoint <code>/api/generate</code> met een OpenAI-sleutel om automatisch een tagline te genereren.
-            </div>
-          </section>
-        </main>
+            </section>
+          </main>
 
         <footer class="editor-footer u-footer">
           Bewaar je wijzigingen lokaal en deel je kaart. De AI-functie gebruikt het serverless endpoint met
           <code>OPENAI_API_KEY</code>.
         </footer>
       </div>
+    </div>
     </div>
 
     <script src="./app.js"></script>

--- a/theme.hypermodern.css
+++ b/theme.hypermodern.css
@@ -17,31 +17,51 @@ body{
     #0B1020;
   font-family:Inter,ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
   -webkit-font-smoothing:antialiased; line-height:1.55;
+  font-size:clamp(14px,1.9vw,16px);
+}
+body::before, body::after{
+  content:""; position:fixed; pointer-events:none; z-index:-1; border-radius:50%;
+  filter:blur(60px); opacity:.28;
+}
+body::before{
+  width:36vw; height:36vw; left:-10vw; top:-8vw;
+  background:radial-gradient(closest-side, rgba(59,130,246,.35), transparent);
+}
+body::after{
+  width:44vw; height:44vw; right:-12vw; top:-4vw;
+  background:radial-gradient(closest-side, rgba(139,92,246,.35), transparent);
 }
 a{color:inherit; text-decoration:none}
 img{max-width:100%; display:block}
 
 /* Navbar: glass + blur */
-.u-navbar{
-  position:sticky; top:0; z-index:50;
-  background: var(--glass);
-  backdrop-filter: blur(14px) saturate(1.2);
-  border-bottom:1px solid rgba(255,255,255,.08);
+.u-navbar{position:sticky; top:0; z-index:50; background:rgba(255,255,255,.08); backdrop-filter:blur(14px) saturate(1.2); border-bottom:1px solid rgba(255,255,255,.08);}
+.u-navbar .inner{display:flex; align-items:center; justify-content:space-between; gap:12px; padding:12px 18px}
+.brand a{font-weight:800; letter-spacing:.2px;}
+.site-nav{display:flex; align-items:center; gap:12px;}
+.site-nav a{padding:10px 12px; border-radius:10px;}
+.nav-toggle{display:none;}
+.nav-btn{display:none; cursor:pointer; padding:10px 12px; border:1px solid rgba(255,255,255,.18); border-radius:12px;}
+@media (max-width:860px){
+  .nav-btn{display:inline-flex;}
+  .site-nav{display:none; position:absolute; left:0; right:0; top:100%; padding:12px; background:rgba(11,16,32,.96); border-bottom:1px solid rgba(255,255,255,.08); flex-direction:column; gap:8px;}
+  .nav-toggle:checked ~ .site-nav{display:flex;}
 }
-.u-navbar .inner{display:flex; align-items:center; justify-content:space-between; padding:14px 22px}
 
 /* Hero fullscreen */
-.hero{min-height:88vh; display:grid; place-items:center; padding:32px; width:100%}
-.hero .content{max-width:960px; text-align:center}
-.hero .actions{display:flex; gap:16px; flex-wrap:wrap; justify-content:center; margin-top:32px}
+.hero{min-height:80vh; display:grid; place-items:center; padding:clamp(20px,6vw,48px); width:100%}
+.hero .content{max-width:960px; margin:0 auto; text-align:center}
+.hero .actions{display:flex; gap:12px; flex-wrap:wrap; justify-content:center; margin-top:32px}
 .hero .actions .u-btn{min-width:180px}
-h1{font-size:clamp(36px,7vw,64px); line-height:1.05; margin:0 0 10px}
+@media (max-width:768px){.hero{min-height:65vh;}}
+h1{font-size:clamp(28px,6vw,64px); line-height:1.05; margin:0 0 10px}
+h2{font-size:clamp(20px,3.5vw,28px); margin:0 0 8px}
 p.lead{color:var(--muted); font-size:clamp(16px,2.5vw,20px); margin:0}
 
 /* Buttons */
 .u-btn{
   display:inline-flex; align-items:center; justify-content:center; gap:10px;
-  padding:14px 22px; border-radius:999px; border:1px solid transparent;
+  padding:14px 22px; min-height:44px; border-radius:999px; border:1px solid transparent;
   font-weight:700; cursor:pointer; transition:.2s transform ease, .2s box-shadow ease, .2s background ease;
 }
 .u-btn:focus{box-shadow:0 0 0 6px var(--ring)}
@@ -52,11 +72,12 @@ p.lead{color:var(--muted); font-size:clamp(16px,2.5vw,20px); margin:0}
 .tabs .u-btn{width:100%; justify-content:center}
 .tabs button.u-btn{background:rgba(255,255,255,.04); border-color:rgba(255,255,255,.12); color:#E6EAF2; padding:12px 16px}
 .tabs button.u-btn[aria-selected="true"]{background:rgba(59,130,246,.2); border-color:rgba(99,102,241,.35); color:#fff}
+@media (max-width:560px){.u-btn{width:100%;}}
 
 /* Cards */
 .u-card{
   background:#0F152A; border:1px solid rgba(255,255,255,.08);
-  border-radius:var(--radius); box-shadow:var(--shadow); padding:22px;
+  border-radius:18px; box-shadow:var(--shadow); padding:clamp(16px,4vw,24px);
   transition:.25s transform ease, .25s box-shadow ease;
 }
 .u-card:hover{transform:translateY(-3px); box-shadow:0 30px 80px rgba(0,0,0,.5)}
@@ -74,20 +95,24 @@ p.lead{color:var(--muted); font-size:clamp(16px,2.5vw,20px); margin:0}
 
 /* Footer */
 .u-footer{
-  margin-top:40px; padding:26px; text-align:center; color:var(--muted);
+  margin-top:40px; padding:clamp(14px,3.5vw,26px); text-align:center; color:var(--muted);
   background:rgba(255,255,255,.04); border-top:1px solid rgba(255,255,255,.08);
 }
 
 /* Helpers */
-.container{max-width:1100px; margin:0 auto; padding:24px}
-.grid{display:grid; gap:18px}
+.container{max-width:1120px; margin:0 auto; padding:clamp(16px,4vw,24px)}
+.grid{display:grid; gap:clamp(12px,3.5vw,18px)}
 .grid.cols-2{grid-template-columns:repeat(2,minmax(0,1fr))}
-@media (max-width:860px){ .grid.cols-2{grid-template-columns:1fr} }
+@media (max-width:1024px){.grid.cols-2{grid-template-columns:1fr}}
 
 /* Extra’s voor jouw HTML */
 .muted{ color: var(--muted); }
 .pill{display:inline-block; padding:6px 10px; border-radius:999px; background:rgba(255,255,255,.08); color:#E6EAF2; border:1px solid rgba(255,255,255,.14); font-size:12px; line-height:1;}
 .notice{margin-top:12px; padding:12px 14px; border-radius:14px; background:rgba(59,130,246,.08); border:1px solid rgba(59,130,246,.25); color:#E6EAF2;}
-.preview{ display:flex; gap:14px; align-items:center; }
-.avatar{ width:72px; height:72px; border-radius:50%; background:#0C1226; border:1px solid rgba(255,255,255,.12); object-fit:cover;}
+.preview{ display:flex; gap:14px; align-items:center; flex-wrap:wrap; }
+.avatar{ width:88px; height:88px; border-radius:50%; background:#0C1226; border:1px solid rgba(255,255,255,.12); object-fit:cover;}
 .editor-footer{ color:var(--muted); text-align:center; padding:16px 0; }
+@media (max-width:560px){
+  .avatar{width:64px; height:64px;}
+  .preview{flex-direction:column; align-items:flex-start;}
+}


### PR DESCRIPTION
## Summary
- maak de dashboardheader mobielvriendelijk met glassy navbar en hero boven de content
- herstructureer de dashboardlayout naar een container + grid die op mobiel stapelt
- werk het hypermoderne thema bij met fluid typography, hero- en kaartpolish en mobiele touchtargets

## Testing
- niet uitgevoerd (statiche HTML/CSS-update)


------
https://chatgpt.com/codex/tasks/task_e_68c9d1ecd8948327a907ea5f601c1396