### PR TITLE
Update theme stylesheet link references

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -10,7 +10,7 @@
     />
     <link rel="icon" href="./favicon.svg" />
     <link rel="stylesheet" href="./styles.css" />
-    <link rel="stylesheet" href="theme.hypermodern.css?v=7">
+    <link rel="stylesheet" href="./theme.hypermodern.css?v=9">
   </head>
   <body class="page-dashboard" data-page="dashboard">
     <header class="site-header u-navbar">

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     />
     <link rel="icon" href="./favicon.svg" />
     <link rel="stylesheet" href="./styles.css" />
-    <link rel="stylesheet" href="theme.hypermodern.css?v=3" />
+    <link rel="stylesheet" href="./theme.hypermodern.css?v=9">
   </head>
   <body class="page-auth" data-page="auth">
     <header class="site-header u-navbar">


### PR DESCRIPTION
## Summary
- point dashboard and index HTML pages to the new hypermodern theme stylesheet version 9
- ensure the stylesheet link uses a relative path so it sits last in each head section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca4d6c761c8327a00cc0962784fa31